### PR TITLE
Add static property tycoon web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Money Games - Property Tycoon
+
+A lightweight, client-side property management mini-game built for GitHub Pages. Grow your rental empire by purchasing properties, collecting rent, and balancing your cash flow.
+
+## Gameplay overview
+
+- **Starting funds:** $1,000 and one in-game day already underway.
+- **Goal:** Purchase properties to increase the rent you earn at the end of every day.
+- **Passive income:** Owned properties automatically generate rent during each tick (in-game day).
+- **History log:** Track purchases, income, and system events in the activity panel.
+
+## Controls and UI
+
+The interface is split into three primary sections:
+
+1. **Player overview**
+   - Shows current day, cash balance, and total rent per in-game day.
+   - Game speed selector (`0.5×`, `1×`, `2×`, `4×`) adjusts how quickly days pass in real time.
+   - Reset button returns the game to day 1 with the initial $1,000 capital.
+2. **Property portfolio**
+   - Displays each available property with its cost, rent yield, and flavour text.
+   - Buttons become disabled once a property is owned or if you lack funds for the purchase.
+3. **Rental income status & activity history**
+   - Owned properties are summarised with their current rent output.
+   - A live-updating feed lists rent events, speed changes, resets, and purchases.
+
+## How rent and days work
+
+- Every real-world second (or faster/slower if you change speed) advances the game by one day.
+- Rent collected per tick equals the sum of rent from all owned properties and is automatically added to your balance.
+- Attempts to purchase a property without enough cash are logged to the activity history for quick troubleshooting.
+
+## Running locally
+
+Because the game is a static HTML page, no build tools are required:
+
+```bash
+# Serve locally with any static HTTP server
+python3 -m http.server
+```
+
+Then browse to `http://localhost:8000` to play. All assets load from the repository and CDN, so no backend or API keys are necessary.
+
+## Deployment
+
+The included GitHub Actions workflow (`.github/workflows/static.yml`) uploads the repository contents directly to GitHub Pages. No extra build steps are needed—committing the HTML, CSS, and JavaScript files is sufficient for deployment.
+
+## Customisation ideas
+
+- Add more properties or tune costs/rents inside `assets/js/game.js`.
+- Extend the CSS theme in `assets/css/styles.css` to match your brand.
+- Track additional metrics (e.g., net worth, ROI) or introduce property upgrades.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,33 @@
+body {
+  min-height: 100vh;
+}
+
+.history-log {
+  max-height: 320px;
+  overflow-y: auto;
+  font-family: "Fira Code", "Courier New", monospace;
+  font-size: 0.95rem;
+}
+
+.property-card.owned {
+  border: 2px solid #198754;
+  box-shadow: 0 0 0.5rem rgba(25, 135, 84, 0.35);
+}
+
+.property-card .btn:disabled {
+  cursor: not-allowed;
+}
+
+#playerBalance {
+  font-size: 1.5rem;
+}
+
+.list-group-item + .list-group-item {
+  border-top: 1px dashed rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 576px) {
+  #playerBalance {
+    font-size: 1.2rem;
+  }
+}

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,0 +1,262 @@
+(() => {
+  const defaultProperties = [
+    {
+      id: "studio",
+      name: "Studio Apartment",
+      description: "An affordable entry into the market.",
+      cost: 350,
+      rent: 35,
+    },
+    {
+      id: "townhouse",
+      name: "City Townhouse",
+      description: "Popular with young professionals.",
+      cost: 650,
+      rent: 85,
+    },
+    {
+      id: "suburb",
+      name: "Suburban Family Home",
+      description: "Stable tenants, steady rent flow.",
+      cost: 900,
+      rent: 125,
+    },
+    {
+      id: "penthouse",
+      name: "Luxury Penthouse",
+      description: "High maintenance, higher reward.",
+      cost: 1400,
+      rent: 240,
+    },
+  ];
+
+  const state = {
+    balance: 0,
+    day: 1,
+    properties: [],
+    history: [],
+    tickLength: 1000,
+    timerId: null,
+  };
+
+  const elements = {};
+
+  function cacheElements() {
+    elements.balance = document.getElementById("playerBalance");
+    elements.day = document.getElementById("currentDay");
+    elements.rentPerDay = document.getElementById("rentPerDay");
+    elements.propertyList = document.getElementById("propertyList");
+    elements.incomeStatus = document.getElementById("incomeStatus");
+    elements.historyLog = document.getElementById("historyLog");
+    elements.resetButton = document.getElementById("resetButton");
+    elements.speedControl = document.getElementById("speedControl");
+  }
+
+  function formatCurrency(amount) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+
+  function cloneDefaultProperties() {
+    return defaultProperties.map((property) => ({ ...property, owned: false }));
+  }
+
+  function initialiseGameState(logInitialMessage = true) {
+    state.balance = 1000;
+    state.day = 1;
+    state.properties = cloneDefaultProperties();
+    state.history = [];
+    if (logInitialMessage) {
+      addHistoryEntry("New game started with $1,000 in capital.");
+    } else {
+      renderHistory();
+    }
+    updateUI();
+    restartTimer();
+  }
+
+  function addHistoryEntry(message) {
+    const timestamp = new Date().toLocaleTimeString();
+    state.history.push({ message, timestamp });
+    if (state.history.length > 50) {
+      state.history.shift();
+    }
+    renderHistory();
+  }
+
+  function restartTimer() {
+    if (state.timerId) {
+      clearInterval(state.timerId);
+    }
+    state.timerId = setInterval(handleDayTick, state.tickLength);
+  }
+
+  function handleSpeedChange(event) {
+    const newLength = Number.parseInt(event.target.value, 10);
+    if (Number.isFinite(newLength) && newLength > 0) {
+      state.tickLength = newLength;
+      restartTimer();
+      addHistoryEntry(`Game speed set to ${(1000 / newLength).toFixed(1)}x.`);
+    }
+  }
+
+  function handleDayTick() {
+    state.day += 1;
+    const rentCollected = calculateRentPerDay();
+    if (rentCollected > 0) {
+      state.balance += rentCollected;
+      addHistoryEntry(
+        `Day ${state.day}: Collected ${formatCurrency(rentCollected)} in rent.`
+      );
+    } else {
+      addHistoryEntry(`Day ${state.day}: No rent collected yet.`);
+    }
+    updateUI();
+  }
+
+  function calculateRentPerDay() {
+    return state.properties
+      .filter((property) => property.owned)
+      .reduce((total, property) => total + property.rent, 0);
+  }
+
+  function handlePurchase(propertyId) {
+    const property = state.properties.find((item) => item.id === propertyId);
+    if (!property || property.owned) {
+      return;
+    }
+
+    if (state.balance < property.cost) {
+      addHistoryEntry(
+        `Attempted to buy ${property.name} but lacked funds (${formatCurrency(
+          property.cost
+        )}).`
+      );
+      return;
+    }
+
+    state.balance -= property.cost;
+    property.owned = true;
+    addHistoryEntry(
+      `Purchased ${property.name} for ${formatCurrency(property.cost)}.`
+    );
+    updateUI();
+  }
+
+  function renderProperties() {
+    elements.propertyList.innerHTML = "";
+    state.properties.forEach((property) => {
+      const col = document.createElement("div");
+      col.className = "col-sm-6";
+
+      const card = document.createElement("div");
+      card.className = "card property-card h-100";
+      if (property.owned) {
+        card.classList.add("owned");
+      }
+
+      const cardBody = document.createElement("div");
+      cardBody.className = "card-body d-flex flex-column";
+
+      const title = document.createElement("h5");
+      title.className = "card-title";
+      title.textContent = property.name;
+
+      const description = document.createElement("p");
+      description.className = "card-text flex-grow-1";
+      description.textContent = property.description;
+
+      const cost = document.createElement("p");
+      cost.className = "mb-1";
+      cost.innerHTML = `<strong>Cost:</strong> ${formatCurrency(property.cost)}`;
+
+      const rent = document.createElement("p");
+      rent.className = "mb-3";
+      rent.innerHTML = `<strong>Rent / day:</strong> ${formatCurrency(
+        property.rent
+      )}`;
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-primary w-100 mt-auto";
+      button.textContent = property.owned ? "Owned" : "Buy property";
+      button.disabled = property.owned || state.balance < property.cost;
+      button.addEventListener("click", () => handlePurchase(property.id));
+
+      cardBody.append(title, description, cost, rent, button);
+      card.append(cardBody);
+      col.append(card);
+      elements.propertyList.append(col);
+    });
+  }
+
+  function renderIncomeStatus() {
+    elements.incomeStatus.innerHTML = "";
+    const ownedProperties = state.properties.filter((property) => property.owned);
+
+    if (ownedProperties.length === 0) {
+      const emptyItem = document.createElement("li");
+      emptyItem.className = "list-group-item py-3";
+      emptyItem.textContent = "No properties owned yet. Buy your first home to start earning rent.";
+      elements.incomeStatus.append(emptyItem);
+      return;
+    }
+
+    ownedProperties.forEach((property) => {
+      const item = document.createElement("li");
+      item.className = "list-group-item d-flex justify-content-between align-items-center";
+      item.innerHTML = `
+        <span>
+          <strong>${property.name}</strong>
+          <small class="d-block text-muted">${property.description}</small>
+        </span>
+        <span class="badge bg-success rounded-pill">${formatCurrency(property.rent)}</span>
+      `;
+      elements.incomeStatus.append(item);
+    });
+  }
+
+  function renderHistory() {
+    if (!elements.historyLog) return;
+    const recentEvents = state.history.slice(-20).reverse();
+    elements.historyLog.innerHTML = recentEvents
+      .map(
+        ({ message, timestamp }) =>
+          `<div class="history-entry"><span class="text-muted">[${timestamp}]</span> ${message}</div>`
+      )
+      .join("");
+  }
+
+  function updateUI() {
+    elements.balance.textContent = formatCurrency(state.balance);
+    elements.day.textContent = state.day.toString();
+    const rentPerDay = calculateRentPerDay();
+    elements.rentPerDay.textContent = formatCurrency(rentPerDay);
+    renderProperties();
+    renderIncomeStatus();
+    renderHistory();
+  }
+
+  function resetGame() {
+    initialiseGameState(false);
+    addHistoryEntry("Game reset. Starting over with fresh capital.");
+    addHistoryEntry("New game started with $1,000 in capital.");
+  }
+
+  function wireUpEvents() {
+    elements.resetButton.addEventListener("click", () => {
+      resetGame();
+    });
+
+    elements.speedControl.addEventListener("change", handleSpeedChange);
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    cacheElements();
+    wireUpEvents();
+    initialiseGameState();
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Money Games - Property Tycoon</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container">
+        <span class="navbar-brand mb-0 h1">Money Games</span>
+        <span class="navbar-text">Property Tycoon Simulator</span>
+      </div>
+    </nav>
+
+    <main class="container my-4">
+      <div class="row g-4">
+        <section class="col-12 col-lg-4">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-success text-white">Player Overview</div>
+            <div class="card-body">
+              <p class="lead">Current Day: <span id="currentDay">1</span></p>
+              <p class="lead">
+                Balance: <span id="playerBalance" class="fw-bold text-success"></span>
+              </p>
+              <div class="mb-3">
+                <label for="speedControl" class="form-label">Game speed</label>
+                <select id="speedControl" class="form-select">
+                  <option value="2000">0.5x (slow &amp; steady)</option>
+                  <option value="1000" selected>1x (default)</option>
+                  <option value="500">2x (fast)</option>
+                  <option value="250">4x (very fast)</option>
+                </select>
+              </div>
+              <button id="resetButton" class="btn btn-outline-danger w-100">
+                Reset Game
+              </button>
+            </div>
+            <div class="card-footer text-muted">
+              Rent per Day: <span id="rentPerDay">0</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="col-12 col-lg-8">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-info text-white">Property Portfolio</div>
+            <div class="card-body">
+              <p>
+                Purchase properties to build your rental empire. Each property
+                generates rent at the end of every in-game day. Owned
+                properties are highlighted below.
+              </p>
+              <div id="propertyList" class="row g-3"></div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="row g-4 mt-1">
+        <section class="col-12 col-lg-6">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-warning">Rental Income Status</div>
+            <div class="card-body">
+              <ul id="incomeStatus" class="list-group list-group-flush"></ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="col-12 col-lg-6">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-secondary text-white">
+              Activity History
+            </div>
+            <div class="card-body">
+              <div
+                id="historyLog"
+                class="history-log border rounded p-3 bg-white"
+                aria-live="polite"
+              ></div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="py-4 bg-dark text-white">
+      <div class="container text-center">
+        <small>
+          Tip: Try to balance cash on hand with new investments to maximise
+          income growth.
+        </small>
+      </div>
+    </footer>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
+    <script src="assets/js/game.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Bootstrap-powered landing page that lays out the player overview, property list, and activity log
- implement the client-side game loop for purchasing properties, advancing days, and collecting rent
- provide base styling and documentation so the static GitHub Pages workflow can deploy the game

## Testing
- python3 -m http.server


------
https://chatgpt.com/codex/tasks/task_e_68d99988b028832bbced77b178a10893