### PR TITLE
Switch rent accrual to monthly yields

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
               </button>
             </div>
             <div class="card-footer text-muted">
-              Rent per Day: <span id="rentPerDay">0</span>
+              Rent per Month: <span id="rentPerMonth">0</span>
             </div>
           </div>
         </section>
@@ -55,7 +55,7 @@
             <div class="card-body">
               <p>
                 Purchase properties to build your rental empire. Each property
-                generates rent at the end of every in-game day. Owned
+                generates rent at the end of every in-game month. Owned
                 properties are highlighted below.
               </p>
               <div id="propertyList" class="row g-3"></div>


### PR DESCRIPTION
## Summary
- add demand-driven yields, monthly rent calculations, and richer location metadata to each default property
- shift game state to calculate and collect rent on a 30-day cadence with updated history logging
- refresh the UI to present rent per month totals across property cards, income status, and the player overview

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9a5a7ef40832bb01788a5fe155406