### PR TITLE
Improve property grid responsiveness and scrolling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -18,6 +18,13 @@ body {
   cursor: not-allowed;
 }
 
+#propertyList {
+  max-height: 65vh;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  padding-bottom: 0.5rem;
+}
+
 #playerBalance {
   font-size: 1.5rem;
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -635,7 +635,7 @@
     elements.propertyList.innerHTML = "";
     state.market.forEach((property) => {
       const col = document.createElement("div");
-      col.className = "col-sm-6";
+      col.className = "col";
 
       const card = document.createElement("div");
       card.className = "card property-card h-100";

--- a/index.html
+++ b/index.html
@@ -58,7 +58,10 @@
                 generates rent at the end of every in-game month. Owned
                 properties are highlighted below.
               </p>
-              <div id="propertyList" class="row g-3"></div>
+              <div
+                id="propertyList"
+                class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3"
+              ></div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- update the property list grid markup to use responsive row-cols classes and align the JavaScript-generated column wrappers
- add a max-height with internal scrolling to the property list so the cards stay accessible without stretching the page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8a3a26a8832bac61f0d7102338f2