### PR TITLE
Slow market regeneration to monthly cadence

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -246,9 +246,9 @@
   const MARKET_CONFIG = {
     maxSize: 8,
     minSize: 4,
-    generationInterval: 3,
+    generationInterval: 30,
     batchSize: 2,
-    maxAge: 12,
+    maxAge: 120,
   };
 
   function calculatePropertyValue(property) {
@@ -442,10 +442,16 @@
 
     const daysSinceGeneration = state.day - state.lastMarketGenerationDay;
     const spaceAvailable = Math.max(MARKET_CONFIG.maxSize - state.market.length, 0);
-    let requiredListings = Math.max(MARKET_CONFIG.minSize - state.market.length, 0);
+    const readyForNewListings = daysSinceGeneration >= MARKET_CONFIG.generationInterval;
 
-    if (requiredListings === 0 && daysSinceGeneration >= MARKET_CONFIG.generationInterval) {
-      requiredListings = getRandomInt(1, MARKET_CONFIG.batchSize);
+    let requiredListings = 0;
+    if (readyForNewListings && spaceAvailable > 0) {
+      const minimumShortfall = Math.max(MARKET_CONFIG.minSize - state.market.length, 0);
+      if (minimumShortfall > 0) {
+        requiredListings = minimumShortfall;
+      } else {
+        requiredListings = getRandomInt(1, MARKET_CONFIG.batchSize);
+      }
     }
 
     const listingsNeeded = Math.min(requiredListings, spaceAvailable);


### PR DESCRIPTION
## Summary
- increase the market generation interval to 30 in-game days to align new listings with a monthly cadence
- update listing refresh logic so new properties only appear after the monthly interval while still respecting market capacity
- extend listing expiration to better match the slower refresh cycle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da8db19428832bb8e37440d2173ab5