### PR TITLE
Reuse forced sale proceeds when processing interest-only maturities

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -889,6 +889,7 @@
     let totalPaid = 0;
     const mortgagesCleared = [];
     const forcedSales = [];
+    let realizedNetProceeds = 0;
 
     for (let index = state.portfolio.length - 1; index >= 0; index -= 1) {
       const property = state.portfolio[index];
@@ -923,7 +924,9 @@
 
       if (mortgage.interestOnly && mortgage.remainingTermMonths <= 0 && mortgage.remainingBalance > 0.5) {
         const outstanding = roundCurrency(mortgage.remainingBalance);
-        const availableBalance = roundCurrency(state.balance - totalPaid);
+        const availableBalance = roundCurrency(
+          state.balance + realizedNetProceeds - totalPaid
+        );
         if (availableBalance >= outstanding) {
           totalPaid += outstanding;
           mortgage.remainingBalance = 0;
@@ -932,6 +935,7 @@
         } else {
           const salePrice = calculateSalePrice(property);
           const netProceeds = roundCurrency(salePrice - outstanding);
+          realizedNetProceeds = roundCurrency(realizedNetProceeds + netProceeds);
           forcedSales.push({
             propertyName: property.name,
             salePrice,


### PR DESCRIPTION
## Summary
- track net proceeds realized from forced sales while iterating mortgage payments
- reuse those proceeds when evaluating later interest-only mortgages before triggering more sales

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68daad776294832b808943ab61a033d3