### PR TITLE
Add configurable financing modal for property mortgages

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,65 @@
       </div>
     </main>
 
+    <div
+      class="modal fade"
+      id="financePropertyModal"
+      tabindex="-1"
+      aria-labelledby="financePropertyModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="financePropertyModalLabel">Finance property</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <h6 id="financePropertyName" class="mb-1"></h6>
+              <p id="financePropertySummary" class="small text-muted mb-0"></p>
+            </div>
+            <div class="mb-3">
+              <h6 class="mb-2">Choose deposit</h6>
+              <div
+                id="financeDepositOptions"
+                class="d-flex flex-wrap gap-2"
+              ></div>
+            </div>
+            <div class="mb-3">
+              <h6 class="mb-2">Fixed-term length</h6>
+              <div id="financeTermOptions" class="d-flex flex-wrap gap-2"></div>
+            </div>
+            <div class="mb-3">
+              <h6 class="mb-2">Payment preview</h6>
+              <div
+                id="financePaymentPreview"
+                class="small bg-light border rounded p-3"
+              ></div>
+              <div id="financeAffordabilityNote" class="small mt-2"></div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-outline-secondary"
+              data-bs-dismiss="modal"
+            >
+              Cancel
+            </button>
+            <button type="button" id="confirmFinanceButton" class="btn btn-primary">
+              Confirm mortgage
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <footer class="py-4 bg-dark text-white">
       <div class="container text-center">
         <small>


### PR DESCRIPTION
## Summary
- replace individual mortgage buttons with a single finance modal trigger that offers configurable deposits and terms
- introduce dynamic mortgage pricing helpers that drive payment previews and affordability messaging in the modal
- send the selected financing options to an updated mortgage purchase handler so deposits use the chosen percentage

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68dab59017a0832b8227ac0ce787b5bf