### PR TITLE
Handle mortgages moving to variable rate phase

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -9,6 +9,25 @@ body {
   font-size: 0.95rem;
 }
 
+.badge-variable-rate {
+  background-color: #ffe08a;
+  color: #5c4400;
+  border: 1px solid rgba(92, 68, 0, 0.35);
+  box-shadow: 0 0.25rem 0.5rem rgba(92, 68, 0, 0.15);
+  letter-spacing: 0.08em;
+  font-size: 0.65rem;
+}
+
+.list-group-item.variable-rate-mortgage {
+  border-left: 4px solid #f7b731;
+  background-image: linear-gradient(
+    90deg,
+    rgba(247, 183, 49, 0.18),
+    rgba(247, 183, 49, 0.05) 55%,
+    transparent
+  );
+}
+
 .property-card.owned {
   border: 2px solid #198754;
   box-shadow: 0 0 0.5rem rgba(25, 135, 84, 0.35);


### PR DESCRIPTION
## Summary
- detect when a mortgage’s fixed period expires during monthly processing, switch it to the variable margin, and emit a history entry
- recalculate ongoing payments at the reversion rate when the variable phase begins and expose helpers for the fixed-period math
- surface the variable-rate status in the income list with a highlighted badge and supporting styles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dad4943eac832b889a9a0d9aa5ba91