### PR TITLE
Display central bank rate in overview

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -48,6 +48,10 @@ body {
   font-size: 1.5rem;
 }
 
+#centralBankRate {
+  font-variant-numeric: tabular-nums;
+}
+
 .list-group-item + .list-group-item {
   border-top: 1px dashed rgba(0, 0, 0, 0.1);
 }

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -518,6 +518,7 @@
   function cacheElements() {
     elements.balance = document.getElementById("playerBalance");
     elements.day = document.getElementById("currentDay");
+    elements.centralBankRate = document.getElementById("centralBankRate");
     elements.rentPerMonth = document.getElementById("rentPerMonth");
     elements.propertyList = document.getElementById("propertyList");
     elements.incomeStatus = document.getElementById("incomeStatus");
@@ -566,6 +567,13 @@
       return "-";
     }
     return `${Math.round(value * 100)}%`;
+  }
+
+  function formatInterestRate(value) {
+    if (!Number.isFinite(value)) {
+      return "-";
+    }
+    return `${(value * 100).toFixed(2)}%`;
   }
 
   function deriveMortgageRateProfile({ depositRatio, termYears, baseRate } = {}) {
@@ -1965,6 +1973,9 @@
   function updateUI() {
     elements.balance.textContent = formatCurrency(state.balance);
     elements.day.textContent = state.day.toString();
+    if (elements.centralBankRate) {
+      elements.centralBankRate.textContent = formatInterestRate(state.centralBankRate);
+    }
     const grossRent = calculateRentPerMonth();
     const mortgageOutgoings = calculateMonthlyMortgageOutgoings();
     const netCashflow = calculateNetCashflowPerMonth();

--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
               <p class="lead">
                 Balance: <span id="playerBalance" class="fw-bold text-success"></span>
               </p>
+              <p class="mb-3 text-muted">
+                Central bank base rate:
+                <span id="centralBankRate" class="fw-semibold"></span>
+              </p>
               <div class="mb-3">
                 <label for="speedControl" class="form-label">Game speed</label>
                 <select id="speedControl" class="form-select">


### PR DESCRIPTION
## Summary
- surface the central bank base rate inside the player overview card
- cache and populate the new rate element when refreshing the UI
- tweak styling so the rate figures align with the rest of the summary

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae916dd08832b85a7d9d14d0bf750