### PR TITLE
Add fixed-rate period selection to finance modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,14 @@
               ></div>
             </div>
             <div class="mb-3">
-              <h6 class="mb-2">Fixed-term length</h6>
+              <h6 class="mb-2">Fixed-rate period</h6>
+              <div
+                id="financeFixedPeriodOptions"
+                class="d-flex flex-wrap gap-2"
+              ></div>
+            </div>
+            <div class="mb-3">
+              <h6 class="mb-2">Total term length</h6>
               <div id="financeTermOptions" class="d-flex flex-wrap gap-2"></div>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- add dedicated fixed-rate period options to the finance modal and mortgage state handling
- update mortgage rate derivation and creation utilities to use the separate fixed period alongside the total term
- refresh UI copy and defaults so previews and history entries reflect the selected intro fixed period

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9d1b345c832b9809ed6ba65ecb51