### PR TITLE
Add property management modal for property controls

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -56,8 +56,181 @@ body {
   border-top: 1px dashed rgba(0, 0, 0, 0.1);
 }
 
+.management-modal .modal-header {
+  align-items: flex-start;
+}
+
+.management-summary {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.management-summary .management-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.management-layout {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.management-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.management-nav-link {
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0.5rem;
+  background: #f8f9fa;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.management-nav-link:hover,
+.management-nav-link:focus {
+  background: #e9f2ff;
+  color: #0d6efd;
+  outline: none;
+}
+
+.management-nav-link.active {
+  background: #0d6efd;
+  color: #fff;
+  box-shadow: 0 0.125rem 0.5rem rgba(13, 110, 253, 0.3);
+}
+
+.management-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.management-section {
+  display: none;
+}
+
+.management-section.active {
+  display: block;
+}
+
+.management-section .section-card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.05);
+}
+
+.management-section .section-card h6 {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+  color: #6c757d;
+}
+
+.management-grid-two {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.management-progress {
+  height: 0.75rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.management-progress-bar {
+  background: linear-gradient(90deg, #0d6efd, #0b5ed7);
+  height: 100%;
+}
+
+.management-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.management-note {
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+.management-finance-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.management-finance-preview {
+  background: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.management-empty-state {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #6c757d;
+  border: 1px dashed rgba(0, 0, 0, 0.15);
+  border-radius: 0.75rem;
+  background: #fff;
+}
+
+.management-summary-stats {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.management-summary-stats .stat-card {
+  background: #fff;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0.75rem 1rem;
+  box-shadow: 0 0.125rem 0.35rem rgba(0, 0, 0, 0.05);
+}
+
+.management-summary-stats .stat-card h6 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6c757d;
+  margin-bottom: 0.25rem;
+}
+
+.management-summary-stats .stat-card strong {
+  font-size: 1.05rem;
+}
+
 @media (max-width: 576px) {
   #playerBalance {
     font-size: 1.2rem;
+  }
+
+  .management-layout {
+    flex-direction: column;
+  }
+
+  .management-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .management-nav-link {
+    flex: 1 1 45%;
+    text-align: center;
   }
 }

--- a/index.html
+++ b/index.html
@@ -100,6 +100,146 @@
 
     <div
       class="modal fade"
+      id="managementModal"
+      tabindex="-1"
+      aria-labelledby="managementModalLabel"
+      aria-modal="true"
+      role="dialog"
+      data-bs-focus="true"
+    >
+      <div class="modal-dialog modal-dialog-scrollable modal-xl">
+        <div class="modal-content management-modal">
+          <div class="modal-header">
+            <div>
+              <h5 class="modal-title" id="managementModalLabel">Property management</h5>
+              <p id="managementModalSubtitle" class="mb-0 small text-muted"></p>
+            </div>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close management hub"
+            ></button>
+          </div>
+          <div class="modal-body">
+            <div class="management-summary" id="managementModalSummary"></div>
+            <div class="management-layout">
+              <nav
+                id="managementSectionNav"
+                class="management-nav"
+                role="tablist"
+                aria-orientation="vertical"
+              >
+                <button
+                  type="button"
+                  class="management-nav-link active"
+                  data-section="overview"
+                  id="management-tab-overview"
+                  aria-controls="management-panel-overview"
+                  aria-selected="true"
+                >
+                  Overview
+                </button>
+                <button
+                  type="button"
+                  class="management-nav-link"
+                  data-section="leasing"
+                  id="management-tab-leasing"
+                  aria-controls="management-panel-leasing"
+                  aria-selected="false"
+                >
+                  Leasing
+                </button>
+                <button
+                  type="button"
+                  class="management-nav-link"
+                  data-section="financing"
+                  id="management-tab-financing"
+                  aria-controls="management-panel-financing"
+                  aria-selected="false"
+                >
+                  Financing
+                </button>
+                <button
+                  type="button"
+                  class="management-nav-link"
+                  data-section="transactions"
+                  id="management-tab-transactions"
+                  aria-controls="management-panel-transactions"
+                  aria-selected="false"
+                >
+                  Buying &amp; Selling
+                </button>
+                <button
+                  type="button"
+                  class="management-nav-link"
+                  data-section="maintenance"
+                  id="management-tab-maintenance"
+                  aria-controls="management-panel-maintenance"
+                  aria-selected="false"
+                >
+                  Maintenance
+                </button>
+              </nav>
+              <div class="management-content">
+                <section
+                  id="management-panel-overview"
+                  class="management-section active"
+                  role="tabpanel"
+                  aria-labelledby="management-tab-overview"
+                >
+                  <div id="managementOverview"></div>
+                </section>
+                <section
+                  id="management-panel-leasing"
+                  class="management-section"
+                  role="tabpanel"
+                  aria-labelledby="management-tab-leasing"
+                >
+                  <div id="managementLeasing"></div>
+                </section>
+                <section
+                  id="management-panel-financing"
+                  class="management-section"
+                  role="tabpanel"
+                  aria-labelledby="management-tab-financing"
+                >
+                  <div id="managementFinancing"></div>
+                </section>
+                <section
+                  id="management-panel-transactions"
+                  class="management-section"
+                  role="tabpanel"
+                  aria-labelledby="management-tab-transactions"
+                >
+                  <div id="managementTransactions"></div>
+                </section>
+                <section
+                  id="management-panel-maintenance"
+                  class="management-section"
+                  role="tabpanel"
+                  aria-labelledby="management-tab-maintenance"
+                >
+                  <div id="managementMaintenance"></div>
+                </section>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-outline-secondary"
+              data-bs-dismiss="modal"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="modal fade"
       id="financePropertyModal"
       tabindex="-1"
       aria-labelledby="financePropertyModalLabel"


### PR DESCRIPTION
## Summary
- add an accessible management modal to index.html for overview, leasing, financing, transactions, and maintenance panels
- build management state and rendering helpers in game.js to populate the new modal and route former inline actions through it
- refresh property and income listings to use Manage triggers and apply supportive styling for the modal layout

## Testing
- node --check assets/js/game.js

------
https://chatgpt.com/codex/tasks/task_e_68dcc26fd75c832b8caea94e4d3d3535