### PR TITLE
Add modal pause controls for the simulation timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,16 @@
           <div class="card shadow-sm h-100">
             <div class="card-header bg-success text-white">Player Overview</div>
             <div class="card-body">
-              <p class="lead">Current Day: <span id="currentDay">1</span></p>
+              <p class="lead">
+                Current Day:
+                <span id="currentDay">1</span>
+                <span
+                  id="gamePausedBadge"
+                  class="badge bg-warning text-dark ms-2 d-none"
+                >
+                  Paused
+                </span>
+              </p>
               <p class="lead">
                 Balance: <span id="playerBalance" class="fw-bold text-success"></span>
               </p>


### PR DESCRIPTION
## Summary
- add pause/resume helpers that clear and restart the simulation timer with nested modal awareness
- disable the speed control and surface a paused badge while gameplay is halted
- hook the finance and management modals into the new pause/resume helpers so the timer restarts when dialogs close

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcc75f052c832bb07fbbc3ee49327a