### PR TITLE
Adjust maintenance decay to match design rates

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -87,8 +87,8 @@ export const propertyTypeMultipliers = {
 
 export const MAINTENANCE_CONFIG = {
   initialPercentRange: [25, 75],
-  occupiedDecayPerMonth: 4,
-  unoccupiedDecayPerMonth: 2,
+  occupiedDecayPerMonth: 1,
+  unoccupiedDecayPerMonth: 0.2,
   refurbishmentCostRatio: 0.25,
   criticalThreshold: 25,
 };

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -66,7 +66,8 @@ import {
     if (!Number.isFinite(value)) {
       return 0;
     }
-    return Math.min(Math.max(Math.round(value), 0), 100);
+    const clamped = Math.min(Math.max(value, 0), 100);
+    return Math.round(clamped * 10) / 10;
   }
 
   function calculateMaintenanceAdjustedValue(baseValue, maintenancePercent) {


### PR DESCRIPTION
## Summary
- align maintenance decay configuration with the intended 1% occupied and 0.2% vacant monthly drop
- preserve fractional maintenance percentages by clamping to a single decimal place instead of whole numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcccae1934832b9fe637b10a52c8d5