### PR TITLE
Follow-up: preserve maintenance pause for initial auto relist

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1281,6 +1281,13 @@ import {
     if (!canAdvertiseForRent(property)) {
       property.rentalMarketingActive = false;
       property.vacancyMonths = 0;
+      if (
+        property.autoRelist &&
+        !isPropertyVacant(property) &&
+        isMaintenanceBelowRentalThreshold(property)
+      ) {
+        property.rentalMarketingPausedForMaintenance = true;
+      }
       return false;
     }
     property.rentalMarketingActive = true;
@@ -2872,7 +2879,8 @@ import {
       if (purchased.autoRelist) {
         const started = startRentalMarketing(purchased);
         if (!started) {
-          stopRentalMarketing(purchased);
+          purchased.rentalMarketingActive = false;
+          purchased.vacancyMonths = 0;
         }
       } else {
         stopRentalMarketing(purchased);


### PR DESCRIPTION
## Summary
- ensure auto-relist attempts blocked by maintenance mark the property as paused for maintenance
- keep maintenance pause information when preparing newly purchased auto-relist properties

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcded61df8832b8e32ab1df44e2c8c