### PR TITLE
Reset mortgage term counters when re-locking fixed rate

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -3568,6 +3568,8 @@ import {
     mortgage.monthlyInterestRate = monthlyRate;
     mortgage.variableRateMargin = profile.variableRateMargin;
     mortgage.reversionRate = profile.reversionRate;
+    mortgage.termMonths = remainingTermMonths;
+    mortgage.termYears = Math.max(remainingTermMonths / 12, 1 / 12);
     mortgage.fixedPeriodYears = fixedYearsResolved;
     mortgage.fixedPeriodMonths = fixedPeriodMonths;
     mortgage.monthlyPayment = monthlyPayment;


### PR DESCRIPTION
## Summary
- reset the mortgage term months and years to the remaining term during refinance
- ensure the re-locked fixed period is treated as newly started instead of immediately reverting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de71a56af4832ba5707c46d491d2b5