### PR TITLE
Fix maintenance decay when properties become vacant

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1869,8 +1869,9 @@ import {
       ensurePropertyRentSettings(property);
       const currentPercent =
         property.maintenancePercent ?? getInitialMaintenancePercent();
-      const underMaintenance = isPropertyVacant(property);
-      const decayRate = underMaintenance
+      const propertyVacant = isPropertyVacant(property);
+      const tenantActive = hasActiveTenant(property);
+      const decayRate = propertyVacant || !tenantActive
         ? MAINTENANCE_CONFIG.unoccupiedDecayPerMonth ?? 0
         : MAINTENANCE_CONFIG.occupiedDecayPerMonth ?? 0;
 
@@ -1899,7 +1900,7 @@ import {
         }
       }
 
-      if (underMaintenance && property.maintenanceWork) {
+      if (propertyVacant && property.maintenanceWork) {
         property.maintenanceWork.monthsRemaining = Math.max(
           (property.maintenanceWork.monthsRemaining ?? 0) - 1,
           0


### PR DESCRIPTION
## Summary
- ensure monthly maintenance decay uses the unoccupied rate whenever a property lacks an active tenant
- keep maintenance work handling aligned with the updated vacancy check

## Testing
- node --input-type=module <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68dea4441c8c832b8f8cc1190438b40f