### PR TITLE
fix: import global styles in layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import type { Snippet } from 'svelte';
   import favicon from '$lib/assets/favicon.svg';
+  import '../app.css';
 
   let { children }: { children?: Snippet } = $props();
 


### PR DESCRIPTION
## Summary
- import the shared app stylesheet in the root layout so the scaffolded components receive their styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4dd6270f4832b96821ec5d7c83c2d