### PR TITLE
Port config and utility modules to Svelte lib

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,348 @@
+export type PropertyTypeKey = 'apartment' | 'townhouse' | 'single_family' | 'luxury';
+
+export interface PropertyLocation {
+  proximity?: number;
+  schoolRating?: number;
+  crimeScore?: number;
+}
+
+export interface PropertyDefinition {
+  id: string;
+  name: string;
+  description: string;
+  propertyType: PropertyTypeKey;
+  bedrooms: number;
+  bathrooms: number;
+  features: string[];
+  locationDescriptor: string;
+  demandScore: number;
+  location?: PropertyLocation;
+  maintenancePercent?: number;
+}
+
+export interface MaintenanceConfig {
+  initialPercentRange: [number, number];
+  occupiedDecayPerMonth: number;
+  unoccupiedDecayPerMonth: number;
+  refurbishmentCostRatio: number;
+  criticalThreshold: number;
+}
+
+export interface CentralBankConfig {
+  initialRate: number;
+  minimumRate: number;
+  adjustmentIntervalDays: number;
+  maxStepPerAdjustment: number;
+}
+
+export interface RateModelConfig {
+  variableMarginBase: number;
+  variableMarginDepositFactor: number;
+  minimumMargin: number;
+  fixedRateIncentives: Record<number, number>;
+}
+
+export interface FinanceConfig {
+  depositOptions: number[];
+  termOptions: number[];
+  fixedPeriodOptions: number[];
+  defaultDepositRatio: number;
+  defaultTermYears: number;
+  defaultFixedPeriodYears: number;
+  minimumRate: number;
+  maximumRate: number;
+  centralBank: CentralBankConfig;
+  rateModel: RateModelConfig;
+}
+
+export interface ProceduralPropertyArchetype {
+  key: string;
+  propertyType: PropertyTypeKey;
+  names: string[];
+  descriptions: string[];
+  locationDescriptors: string[];
+  bedroomsRange: [number, number];
+  bathroomsRange: [number, number];
+  demandRange: [number, number];
+  proximityRange: [number, number];
+  schoolRange: [number, number];
+  crimeRange: [number, number];
+  maintenancePercentRange: [number, number];
+  featuresPool: string[];
+}
+
+export interface MarketConfig {
+  maxSize: number;
+  minSize: number;
+  generationInterval: number;
+  batchSize: number;
+  maxAge: number;
+}
+
+export type FeatureAddOnMap = Record<string, number>;
+
+export const defaultProperties: PropertyDefinition[] = [
+  {
+    id: 'studio',
+    name: 'Downtown Micro Loft',
+    description: 'Compact living in the heart of the city, perfect for commuters.',
+    propertyType: 'apartment',
+    bedrooms: 1,
+    bathrooms: 1,
+    features: ['City View', 'Shared Rooftop', 'In-Unit Laundry'],
+    locationDescriptor: 'Transit-rich downtown block with nightlife and offices steps away.',
+    demandScore: 9,
+    location: {
+      proximity: 0.95,
+      schoolRating: 5,
+      crimeScore: 4
+    },
+    maintenancePercent: 65
+  },
+  {
+    id: 'townhouse',
+    name: 'Historic Row Townhouse',
+    description: 'Updated interiors with charming brick facade and private entry.',
+    propertyType: 'townhouse',
+    bedrooms: 3,
+    bathrooms: 2,
+    features: ['Private Patio', 'Finished Basement', 'Smart Thermostat'],
+    locationDescriptor: 'Tree-lined heritage street close to cafes and boutique shops.',
+    demandScore: 7,
+    location: {
+      proximity: 0.75,
+      schoolRating: 7,
+      crimeScore: 3
+    },
+    maintenancePercent: 58
+  },
+  {
+    id: 'suburb',
+    name: 'Suburban Cul-de-sac Home',
+    description: 'Spacious single-family house in a top-rated school district.',
+    propertyType: 'single_family',
+    bedrooms: 4,
+    bathrooms: 3,
+    features: ['Two-Car Garage', 'Backyard Deck', 'Home Office'],
+    locationDescriptor: 'Family-friendly cul-de-sac with parks and community amenities.',
+    demandScore: 6,
+    location: {
+      proximity: 0.6,
+      schoolRating: 9,
+      crimeScore: 2
+    },
+    maintenancePercent: 72
+  },
+  {
+    id: 'penthouse',
+    name: 'Skyline Signature Penthouse',
+    description: 'Expansive luxury residence with concierge and spa access.',
+    propertyType: 'luxury',
+    bedrooms: 3,
+    bathrooms: 3,
+    features: ['Private Elevator', 'Wraparound Terrace', 'Floor-to-Ceiling Windows', 'Concierge Service'],
+    locationDescriptor: 'Top-floor suite in a premier downtown landmark tower.',
+    demandScore: 10,
+    location: {
+      proximity: 0.98,
+      schoolRating: 8,
+      crimeScore: 2
+    },
+    maintenancePercent: 52
+  }
+];
+
+export const propertyTypeMultipliers: Record<PropertyTypeKey, number> = {
+  apartment: 0.9,
+  townhouse: 1.05,
+  single_family: 1.15,
+  luxury: 1.35
+};
+
+export const MAINTENANCE_CONFIG: MaintenanceConfig = {
+  initialPercentRange: [25, 75],
+  occupiedDecayPerMonth: 1,
+  unoccupiedDecayPerMonth: 0.2,
+  refurbishmentCostRatio: 0.25,
+  criticalThreshold: 25
+};
+
+export const FINANCE_CONFIG: FinanceConfig = {
+  depositOptions: [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5],
+  termOptions: [2, 5, 10, 25],
+  fixedPeriodOptions: [2, 5, 10],
+  defaultDepositRatio: 0.2,
+  defaultTermYears: 25,
+  defaultFixedPeriodYears: 5,
+  minimumRate: 0.025,
+  maximumRate: 0.085,
+  centralBank: {
+    initialRate: 0.0375,
+    minimumRate: 0.005,
+    adjustmentIntervalDays: 30,
+    maxStepPerAdjustment: 0.0015
+  },
+  rateModel: {
+    variableMarginBase: 0.015,
+    variableMarginDepositFactor: 0.08,
+    minimumMargin: 0.004,
+    fixedRateIncentives: {
+      2: -0.0035,
+      5: -0.0025,
+      10: -0.0015,
+      25: 0
+    }
+  }
+};
+
+export const featureAddOns: FeatureAddOnMap = {
+  'City View': 60,
+  'Shared Rooftop': 40,
+  'In-Unit Laundry': 55,
+  'Private Patio': 65,
+  'Finished Basement': 75,
+  'Smart Thermostat': 30,
+  'Two-Car Garage': 90,
+  'Backyard Deck': 70,
+  'Home Office': 50,
+  'Private Elevator': 120,
+  'Wraparound Terrace': 110,
+  'Floor-to-Ceiling Windows': 85,
+  'Concierge Service': 95
+};
+
+export const proceduralPropertyArchetypes: ProceduralPropertyArchetype[] = [
+  {
+    key: 'urban_loft',
+    propertyType: 'apartment',
+    names: [
+      'Canal View Loft',
+      'Warehouse Loft Residence',
+      'Transit Hub Micro Suite',
+      'Riverside Skyline Flat'
+    ],
+    descriptions: [
+      'Open-concept loft with exposed beams and industrial chic finishes.',
+      'Bright studio with soaring ceilings and premium smart-home upgrades.',
+      'Compact layout designed for efficient city living and quick commutes.'
+    ],
+    locationDescriptors: [
+      'Converted warehouse district steps from artisanal cafes.',
+      'Walkable neighbourhood beside major transit lines.',
+      'Revitalised riverfront promenade with co-working hubs.'
+    ],
+    bedroomsRange: [1, 2],
+    bathroomsRange: [1, 2],
+    demandRange: [6, 9],
+    proximityRange: [0.7, 0.96],
+    schoolRange: [4, 7],
+    crimeRange: [3, 5],
+    maintenancePercentRange: [40, 70],
+    featuresPool: ['City View', 'Shared Rooftop', 'In-Unit Laundry', 'Smart Thermostat', 'Home Office']
+  },
+  {
+    key: 'family_suburb',
+    propertyType: 'single_family',
+    names: [
+      'Meadowridge Colonial',
+      'Lakeside Craftsman Retreat',
+      'Willow Grove Residence',
+      'Sunset Ridge Family Estate'
+    ],
+    descriptions: [
+      'Spacious home with flexible floor plan tailored for growing families.',
+      "Expansive backyard and updated chef's kitchen with breakfast nook.",
+      'Light-filled interiors with formal dining and bonus recreation room.'
+    ],
+    locationDescriptors: [
+      'Quiet cul-de-sac with playgrounds and community pool.',
+      "Top-rated school catchment with weekly farmer's market.",
+      'Lake-adjacent suburb boasting hiking paths and tennis courts.'
+    ],
+    bedroomsRange: [3, 5],
+    bathroomsRange: [2, 4],
+    demandRange: [5, 8],
+    proximityRange: [0.5, 0.75],
+    schoolRange: [7, 10],
+    crimeRange: [1, 3],
+    maintenancePercentRange: [45, 75],
+    featuresPool: ['Two-Car Garage', 'Backyard Deck', 'Home Office', 'Finished Basement', 'Smart Thermostat']
+  },
+  {
+    key: 'luxury_highrise',
+    propertyType: 'luxury',
+    names: [
+      'Aurora Sky Penthouse',
+      'Summit View Grand Suite',
+      'Crown Heights Signature Residence',
+      'Helios Tower Panorama'
+    ],
+    descriptions: [
+      'Designer-curated interiors with private concierge and spa privileges.',
+      'Panoramic skyline vistas paired with bespoke finishes throughout.',
+      'Ultra-premium sky home with wine cellar and home automation package.'
+    ],
+    locationDescriptors: [
+      'Iconic tower above luxury retail promenade and fine dining.',
+      'Flagship high-rise neighbouring cultural and financial districts.',
+      'Prestigious address with private club access and valet services.'
+    ],
+    bedroomsRange: [2, 4],
+    bathroomsRange: [2, 4],
+    demandRange: [8, 10],
+    proximityRange: [0.9, 0.99],
+    schoolRange: [6, 9],
+    crimeRange: [1, 3],
+    maintenancePercentRange: [35, 60],
+    featuresPool: [
+      'Private Elevator',
+      'Wraparound Terrace',
+      'Floor-to-Ceiling Windows',
+      'Concierge Service',
+      'Smart Thermostat'
+    ]
+  },
+  {
+    key: 'urban_townhome',
+    propertyType: 'townhouse',
+    names: [
+      'Cobblestone Row Townhome',
+      'Maple Terrace Brownstone',
+      'Gallery District Duplex',
+      'Heritage Row Garden Home'
+    ],
+    descriptions: [
+      'Updated interiors blend classic masonry with modern conveniences.',
+      'Multi-level plan with flexible workspace and rooftop garden.',
+      'Sun-drenched living areas with custom millwork and smart lighting.'
+    ],
+    locationDescriptors: [
+      'Historic street close to bistros and boutique galleries.',
+      'Transit-friendly district lined with artisan markets.',
+      'Corner row with private courtyard and neighbourhood cafés.'
+    ],
+    bedroomsRange: [2, 4],
+    bathroomsRange: [2, 3],
+    demandRange: [6, 9],
+    proximityRange: [0.65, 0.85],
+    schoolRange: [6, 9],
+    crimeRange: [2, 4],
+    maintenancePercentRange: [40, 68],
+    featuresPool: ['Private Patio', 'Finished Basement', 'Smart Thermostat', 'In-Unit Laundry', 'Home Office']
+  }
+];
+
+export const MARKET_CONFIG: MarketConfig = {
+  maxSize: 8,
+  minSize: 4,
+  generationInterval: 30,
+  batchSize: 2,
+  maxAge: 120
+};
+
+export const propertyTypeLabels: Record<PropertyTypeKey, string> = {
+  apartment: 'Apartment',
+  townhouse: 'Townhouse',
+  single_family: 'Single-Family Home',
+  luxury: 'Luxury Residence'
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,73 @@
+import { propertyTypeLabels } from '$lib/config';
+
+export function getRandomInt(min: number, max: number): number {
+  const lower = Math.ceil(min);
+  const upper = Math.floor(max);
+  return Math.floor(Math.random() * (upper - lower + 1)) + lower;
+}
+
+export function getRandomNumber(min: number, max: number, precision = 2): number {
+  const value = Math.random() * (max - min) + min;
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+export function pickRandom<T>(items: readonly T[]): T {
+  return items[getRandomInt(0, items.length - 1)];
+}
+
+export function selectFeatureSubset(featuresPool: readonly string[]): string[] {
+  if (!Array.isArray(featuresPool) || featuresPool.length === 0) {
+    return [];
+  }
+
+  const maxSelectable = Math.min(featuresPool.length, 4);
+  const minSelectable = Math.min(2, maxSelectable);
+  const subsetSize = getRandomInt(minSelectable, maxSelectable);
+  const poolCopy = [...featuresPool];
+  const selected: string[] = [];
+
+  while (selected.length < subsetSize && poolCopy.length > 0) {
+    const index = getRandomInt(0, poolCopy.length - 1);
+    selected.push(poolCopy.splice(index, 1)[0]);
+  }
+
+  return selected;
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+});
+
+export function formatCurrency(amount: number): string {
+  return currencyFormatter.format(Math.round(amount));
+}
+
+export function roundCurrency(amount: number): number {
+  return Math.round(amount * 100) / 100;
+}
+
+export function roundRate(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+export function formatPropertyType(type: string): string {
+  return propertyTypeLabels[type as keyof typeof propertyTypeLabels] ?? type;
+}
+
+export function formatPercentage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '-';
+  }
+  return `${Math.round(value * 100)}%`;
+}
+
+export function formatInterestRate(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '-';
+  }
+  return `${(value * 100).toFixed(2)}%`;
+}


### PR DESCRIPTION
## Summary
- add a typed config module that centralises property defaults, finance settings, and labels for reuse
- port the legacy utility helpers to TypeScript so randomisation and formatting logic can be shared across the Svelte stores
- update the game store to import the shared config and utilities, reducing inline duplication

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e4ea123080832bb463376498c64689