### PR TITLE
Add leasing management controls to property modal

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,10 @@
     purchaseProperty,
     setManagementSection,
     closeManagement,
+    setPropertyLeaseMonths,
+    setPropertyRentPremium,
+    setPropertyAutoRelist,
+    setPropertyMarketingPaused,
     selectFinanceDeposit,
     selectFinanceTerm,
     selectFinanceFixedPeriod,
@@ -104,6 +108,42 @@
     setFinanceInterestOnly(event.detail);
   }
 
+  function handleLeaseChangeEvent(
+    event: CustomEvent<{ propertyId: string; leaseMonths: number }>
+  ) {
+    const { propertyId, leaseMonths } = event.detail;
+    if (propertyId && Number.isFinite(leaseMonths)) {
+      setPropertyLeaseMonths(propertyId, leaseMonths);
+    }
+  }
+
+  function handleRentChangeEvent(
+    event: CustomEvent<{ propertyId: string; rateOffset: number }>
+  ) {
+    const { propertyId, rateOffset } = event.detail;
+    if (propertyId && Number.isFinite(rateOffset)) {
+      setPropertyRentPremium(propertyId, rateOffset);
+    }
+  }
+
+  function handleAutoRelistToggleEvent(
+    event: CustomEvent<{ propertyId: string; enabled: boolean }>
+  ) {
+    const { propertyId, enabled } = event.detail;
+    if (propertyId) {
+      setPropertyAutoRelist(propertyId, enabled);
+    }
+  }
+
+  function handleMarketingToggleEvent(
+    event: CustomEvent<{ propertyId: string; paused: boolean }>
+  ) {
+    const { propertyId, paused } = event.detail;
+    if (propertyId) {
+      setPropertyMarketingPaused(propertyId, paused);
+    }
+  }
+
   function handleFinanceConfirm() {
     confirmFinance();
   }
@@ -171,7 +211,14 @@
   financingHtml={$managementView.financingHtml}
   transactionsHtml={$managementView.transactionsHtml}
   maintenanceHtml={$managementView.maintenanceHtml}
+  propertyId={$managementView.propertyId}
+  isOwned={$managementView.isOwned}
+  leasingControls={$managementView.leasingControls}
   on:sectionchange={handleManagementSectionChange}
+  on:leasechange={handleLeaseChangeEvent}
+  on:rentchange={handleRentChangeEvent}
+  on:autorelisttoggle={handleAutoRelistToggleEvent}
+  on:marketingtoggle={handleMarketingToggleEvent}
   on:hide={closeManagement}
 />
 


### PR DESCRIPTION
## Summary
- extend the management view to expose leasing plans, marketing flags, and structured control data for the active property
- render interactive leasing controls in the management modal and emit events for lease length, rent premium, auto-relisting, and marketing toggles
- add store handlers that update property state, respect marketing pauses during monthly ticks, and refresh rental summaries when leasing settings change

## Testing
- npm run check
- npm run lint *(fails: existing lint configuration reports numerous pre-existing issues in legacy components)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f0f93264832bb4c4311c5f2b5067