### PR TITLE
Add maintenance scheduling workflow to management modal

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -71,3 +71,20 @@ export function formatInterestRate(value: number): string {
   }
   return `${(value * 100).toFixed(2)}%`;
 }
+
+export function formatLeaseCountdown(months: number): string {
+  if (!Number.isFinite(months) || months <= 0) {
+    return '0 months';
+  }
+  const rounded = Math.round(months);
+  const years = Math.floor(rounded / 12);
+  const remainingMonths = rounded % 12;
+  const parts: string[] = [];
+  if (years > 0) {
+    parts.push(`${years} year${years === 1 ? '' : 's'}`);
+  }
+  if (remainingMonths > 0 || parts.length === 0) {
+    parts.push(`${remainingMonths} month${remainingMonths === 1 ? '' : 's'}`);
+  }
+  return parts.join(' ');
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,6 +34,7 @@
     setPropertyRentPremium,
     setPropertyAutoRelist,
     setPropertyMarketingPaused,
+    schedulePropertyMaintenance,
     selectFinanceDeposit,
     selectFinanceTerm,
     selectFinanceFixedPeriod,
@@ -144,6 +145,13 @@
     }
   }
 
+  function handleMaintenanceScheduleEvent(event: CustomEvent<{ propertyId: string }>) {
+    const { propertyId } = event.detail ?? {};
+    if (propertyId) {
+      schedulePropertyMaintenance(propertyId);
+    }
+  }
+
   function handleFinanceConfirm() {
     confirmFinance();
   }
@@ -214,11 +222,13 @@
   propertyId={$managementView.propertyId}
   isOwned={$managementView.isOwned}
   leasingControls={$managementView.leasingControls}
+  maintenanceState={$managementView.maintenanceState}
   on:sectionchange={handleManagementSectionChange}
   on:leasechange={handleLeaseChangeEvent}
   on:rentchange={handleRentChangeEvent}
   on:autorelisttoggle={handleAutoRelistToggleEvent}
   on:marketingtoggle={handleMarketingToggleEvent}
+  on:maintenanceschedule={handleMaintenanceScheduleEvent}
   on:hide={closeManagement}
 />
 


### PR DESCRIPTION
## Summary
- add a reusable lease countdown formatter for maintenance messaging
- extend the game store with maintenance scheduling state, scheduling logic, and monthly processing updates that pause and resume marketing
- surface maintenance planning controls in the management modal and hook the schedule action up through the page route

## Testing
- npm run lint *(fails: current configuration flags missing DOM globals and legacy {@html} usage across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f61e0d0c832b9eab155e6ff27838