### PR TITLE
Add management actions to rental status

### DIFF
--- a/src/lib/components/RentalStatus.svelte
+++ b/src/lib/components/RentalStatus.svelte
@@ -1,7 +1,22 @@
 <script lang="ts">
-  import type { RentalItem } from '$lib/types';
+  import { createEventDispatcher } from 'svelte';
+
+  import type { RentalItem, RentalItemAction } from '$lib/types';
+
+  const dispatch = createEventDispatcher<{ manage: string }>();
 
   let { items = [] as RentalItem[] } = $props();
+
+  function handleActionClick(item: RentalItem, action: RentalItemAction) {
+    if (action.type !== 'manage') {
+      return;
+    }
+    const propertyId = action.propertyId ?? item.propertyId;
+    if (!propertyId) {
+      return;
+    }
+    dispatch('manage', propertyId);
+  }
 </script>
 
 <section class="col-12 col-lg-6">
@@ -13,8 +28,26 @@
           <li class="list-group-item text-muted">Rental updates will appear here.</li>
         {:else}
           {#each items as item (item.id)}
-            <li class="list-group-item">
-              {@html item.contentHtml}
+            <li class="list-group-item py-3">
+              <div class="d-flex flex-column gap-2">
+                <div class="rental-item-content" class:with-actions={Boolean(item.actions?.length)}>
+                  {@html item.contentHtml}
+                </div>
+                {#if item.actions?.length}
+                  <div class="d-flex flex-wrap align-items-center gap-2">
+                    {#each item.actions as action, index (action.type + (action.propertyId ?? '') + index)}
+                      <button
+                        type="button"
+                        class={action.className ?? 'btn btn-primary btn-sm'}
+                        aria-label={action.ariaLabel ?? action.label}
+                        onclick={() => handleActionClick(item, action)}
+                      >
+                        {action.label}
+                      </button>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
             </li>
           {/each}
         {/if}
@@ -22,3 +55,9 @@
     </div>
   </div>
 </section>
+
+<style>
+  .rental-item-content.with-actions {
+    margin-bottom: 0.25rem;
+  }
+</style>

--- a/src/lib/stores/game.ts
+++ b/src/lib/stores/game.ts
@@ -765,15 +765,23 @@ export const propertyCards = derived(gameState, ($state): PropertyCard[] => {
 
 export const rentalItems = derived(gameState, ($state): RentalItem[] =>
   $state.portfolio.map((property) => {
+    const manageAction = {
+      type: 'manage' as const,
+      label: 'Manage',
+      propertyId: property.id,
+      ariaLabel: `Manage ${property.name}`
+    };
     if (property.tenant) {
       const net = property.tenant.monthlyRent - (property.mortgage?.monthlyPayment ?? 0);
       const netLabel = net >= 0 ? 'Positive cash flow' : 'Negative cash flow';
       const netClass = net >= 0 ? 'text-success' : 'text-danger';
       return {
         id: `rental-${property.id}`,
+        propertyId: property.id,
         contentHtml: `<strong>${property.name}:</strong> Lease ${property.tenant.leaseMonthsRemaining} months remaining. Monthly rent ${formatCurrency(
           property.tenant.monthlyRent
-        )}. <span class="${netClass}">${netLabel} ${formatCurrency(net)}</span>`
+        )}. <span class="${netClass}">${netLabel} ${formatCurrency(net)}</span>`,
+        actions: [manageAction]
       };
     }
     const marketingMessage = property.rentalMarketingPausedForMaintenance
@@ -783,9 +791,11 @@ export const rentalItems = derived(gameState, ($state): RentalItem[] =>
         : 'Vacant — auto-relist disabled.';
     return {
       id: `rental-${property.id}`,
+      propertyId: property.id,
       contentHtml: `<strong>${property.name}:</strong> ${marketingMessage} Expected rent ${formatCurrency(
         property.monthlyRentEstimate
-      )}.`
+      )}.`,
+      actions: [manageAction]
     };
   })
 );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,9 +21,19 @@ export type PropertyCard = {
   manageLabel?: string;
 };
 
+export type RentalItemAction = {
+  type: 'manage';
+  label: string;
+  propertyId?: string;
+  ariaLabel?: string;
+  className?: string;
+};
+
 export type RentalItem = {
   id: string;
+  propertyId?: string;
   contentHtml: string;
+  actions?: RentalItemAction[];
 };
 
 export type HistoryEntry = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -205,7 +205,7 @@
 </div>
 
 <div class="row g-4 mt-1">
-  <RentalStatus items={$rentalItems} />
+  <RentalStatus items={$rentalItems} on:manage={handleManageEvent} />
   <ActivityHistory entries={$historyEntries} />
 </div>
 


### PR DESCRIPTION
## Summary
- add action metadata to rental items produced by the game store
- render manage buttons in the rental status component and emit manage events
- connect the new manage event to the existing manageProperty handler on the page

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e50d864468832bab20da28cfdf04e2