### PR TITLE
feat: add tabbed navigation layout

### DIFF
--- a/src/lib/components/GameSummaryBar.svelte
+++ b/src/lib/components/GameSummaryBar.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  let {
+    currentDay = 1,
+    balanceLabel = '',
+    centralBankRateLabel = ''
+  } = $props();
+</script>
+
+<section class="mb-4" aria-label="Game summary">
+  <div class="row g-3">
+    <div class="col-12 col-md-4">
+      <div class="card shadow-sm h-100 summary-card">
+        <div class="card-body">
+          <p class="text-uppercase text-muted fw-semibold mb-1 small">Current Day</p>
+          <p class="h3 mb-0" id="summaryCurrentDay">{currentDay}</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-4">
+      <div class="card shadow-sm h-100 summary-card">
+        <div class="card-body">
+          <p class="text-uppercase text-muted fw-semibold mb-1 small">Game Balance</p>
+          <p class="h3 mb-0 text-success" id="summaryPlayerBalance">{balanceLabel}</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-4">
+      <div class="card shadow-sm h-100 summary-card">
+        <div class="card-body">
+          <p class="text-uppercase text-muted fw-semibold mb-1 small">Central Bank Rate</p>
+          <p class="h3 mb-0" id="summaryCentralBankRate">{centralBankRateLabel}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .summary-card {
+    border: none;
+    background: linear-gradient(135deg, rgba(13, 110, 253, 0.08), rgba(32, 201, 151, 0.08));
+  }
+</style>

--- a/src/lib/components/PropertyPortfolio.svelte
+++ b/src/lib/components/PropertyPortfolio.svelte
@@ -8,6 +8,7 @@
   }>();
 
   let {
+    title = 'Property Portfolio',
     description =
       'Purchase properties to build your rental empire. Each property generates rent at the end of every in-game month. Owned properties are highlighted below.',
     properties = [] as PropertyCard[],
@@ -25,7 +26,7 @@
 
 <section class="col-12 col-lg-8">
   <div class="card shadow-sm h-100">
-    <div class="card-header bg-info text-white">Property Portfolio</div>
+    <div class="card-header bg-info text-white">{title}</div>
     <div class="card-body">
       <p>{description}</p>
       <div id="propertyList" class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3">


### PR DESCRIPTION
## Summary
- add a persistent game summary bar highlighting day, balance, and central bank rate
- introduce tabbed navigation for dashboard, market, portfolio, and settings views
- allow property cards to reuse the portfolio component with custom titles across tabs

## Testing
- npm run lint *(fails: existing lint violations in legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68e513cb7120832b863a275a6bdd1849