### PR TITLE
Fix monthly cash flow label rendering

### DIFF
--- a/src/lib/components/ActivityHistory.svelte
+++ b/src/lib/components/ActivityHistory.svelte
@@ -4,7 +4,7 @@
   let { entries = [] as HistoryEntry[] } = $props();
 </script>
 
-<section class="col-12 col-lg-6">
+<section class="col-12">
   <div class="card shadow-sm h-100">
     <div class="card-header bg-secondary text-white">Activity History</div>
     <div class="card-body">

--- a/src/lib/components/GameSettings.svelte
+++ b/src/lib/components/GameSettings.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  type SpeedOption = {
+    value: string;
+    label: string;
+  };
+
+  const dispatch = createEventDispatcher<{
+    speedchange: string;
+    reset: void;
+  }>();
+
+  let {
+    speed = '1000',
+    speedOptions = [
+      { value: '2000', label: '0.5x (slow & steady)' },
+      { value: '1000', label: '1x (default)' },
+      { value: '500', label: '2x (fast)' },
+      { value: '250', label: '4x (very fast)' }
+    ] as SpeedOption[]
+  } = $props();
+
+  function handleSpeedChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    speed = value;
+    dispatch('speedchange', value);
+  }
+
+  function handleReset() {
+    dispatch('reset');
+  }
+</script>
+
+<section class="col-12">
+  <div class="card shadow-sm h-100">
+    <div class="card-header bg-primary text-white">Simulation Settings</div>
+    <div class="card-body">
+      <p class="text-muted">
+        Adjust how quickly in-game days progress and reset the game when you want to start again.
+      </p>
+      <div class="row g-3 align-items-end">
+        <div class="col-12 col-md-6">
+          <label for="speedControl" class="form-label">Game speed</label>
+          <select id="speedControl" class="form-select" onchange={handleSpeedChange} bind:value={speed}>
+            {#each speedOptions as option}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+        <div class="col-12 col-md-auto ms-md-auto">
+          <button
+            id="resetButton"
+            class="btn btn-outline-danger w-100"
+            type="button"
+            onclick={handleReset}
+          >
+            Reset Game
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/components/PlayerOverview.svelte
+++ b/src/lib/components/PlayerOverview.svelte
@@ -1,77 +1,44 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
-  type SpeedOption = {
-    value: string;
-    label: string;
-  };
-
-  const dispatch = createEventDispatcher<{
-    speedchange: string;
-    reset: void;
-  }>();
-
   let {
     currentDay = 1,
     isPaused = false,
     balanceLabel = '',
     centralBankRateLabel = '',
-    speed = '1000',
-    speedOptions = [
-      { value: '2000', label: '0.5x (slow & steady)' },
-      { value: '1000', label: '1x (default)' },
-      { value: '500', label: '2x (fast)' },
-      { value: '250', label: '4x (very fast)' }
-    ] as SpeedOption[],
     monthlyCashFlowLabel = '0'
   } = $props();
-
-  function handleSpeedChange(event: Event) {
-    const value = (event.currentTarget as HTMLSelectElement).value;
-    speed = value;
-    dispatch('speedchange', value);
-  }
-
-  function handleReset() {
-    dispatch('reset');
-  }
 </script>
 
-<section class="col-12 col-lg-4">
+<section class="col-12">
   <div class="card shadow-sm h-100">
-    <div class="card-header bg-success text-white">Player Overview</div>
+    <div class="card-header bg-success text-white">Game Snapshot</div>
     <div class="card-body">
-      <p class="lead">
-        Current Day:
-        <span id="currentDay">{currentDay}</span>
-        <span
-          id="gamePausedBadge"
-          class={`badge bg-warning text-dark ms-2${isPaused ? '' : ' d-none'}`}
-        >
-          Paused
-        </span>
-      </p>
-      <p class="lead">
-        Balance: <span id="playerBalance" class="fw-bold text-success">{balanceLabel}</span>
-      </p>
-      <p class="mb-3 text-muted">
-        Central bank base rate:
-        <span id="centralBankRate" class="fw-semibold">{centralBankRateLabel}</span>
-      </p>
-      <div class="mb-3">
-        <label for="speedControl" class="form-label">Game speed</label>
-        <select id="speedControl" class="form-select" onchange={handleSpeedChange} bind:value={speed}>
-          {#each speedOptions as option}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
+      <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+        <div class="col">
+          <p class="text-muted mb-1">Current Day</p>
+          <p class="h4 mb-0 d-flex align-items-center gap-2">
+            <span id="currentDay">{currentDay}</span>
+            <span
+              id="gamePausedBadge"
+              class="badge bg-warning text-dark"
+              class:d-none={!isPaused}
+            >
+              Paused
+            </span>
+          </p>
+        </div>
+        <div class="col">
+          <p class="text-muted mb-1">Portfolio Balance</p>
+          <p class="h4 mb-0 text-success" id="playerBalance">{balanceLabel}</p>
+        </div>
+        <div class="col">
+          <p class="text-muted mb-1">Central Bank Base Rate</p>
+          <p class="h4 mb-0" id="centralBankRate">{centralBankRateLabel}</p>
+        </div>
       </div>
-      <button id="resetButton" class="btn btn-outline-danger w-100" type="button" onclick={handleReset}>
-        Reset Game
-      </button>
     </div>
     <div class="card-footer text-muted">
-      Monthly cash flow: <span id="rentPerMonth">{monthlyCashFlowLabel}</span>
+      Monthly cash flow:
+      <span id="rentPerMonth">{@html monthlyCashFlowLabel}</span>
     </div>
   </div>
 </section>

--- a/src/lib/components/PropertyPortfolio.svelte
+++ b/src/lib/components/PropertyPortfolio.svelte
@@ -24,7 +24,7 @@
   }
 </script>
 
-<section class="col-12 col-lg-8">
+<section class="col-12">
   <div class="card shadow-sm h-100">
     <div class="card-header bg-info text-white">{title}</div>
     <div class="card-body">

--- a/src/lib/components/RentalStatus.svelte
+++ b/src/lib/components/RentalStatus.svelte
@@ -19,7 +19,7 @@
   }
 </script>
 
-<section class="col-12 col-lg-6">
+<section class="col-12">
   <div class="card shadow-sm h-100">
     <div class="card-header bg-warning">Rental Income Status</div>
     <div class="card-body income-status-body">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import PropertyPortfolio from '$lib/components/PropertyPortfolio.svelte';
   import RentalStatus from '$lib/components/RentalStatus.svelte';
   import ActivityHistory from '$lib/components/ActivityHistory.svelte';
+  import GameSettings from '$lib/components/GameSettings.svelte';
   import ManagementModal from '$lib/components/ManagementModal.svelte';
   import FinanceModal from '$lib/components/FinanceModal.svelte';
 
@@ -226,21 +227,7 @@
       balanceLabel={$balanceLabel}
       centralBankRateLabel={$centralBankRateLabel}
       monthlyCashFlowLabel={$monthlyCashFlowLabel}
-      speed={$speedLabel}
-      speedOptions={speedOptions}
-      on:speedchange={handleSpeedChange}
-      on:reset={handleReset}
     />
-    <PropertyPortfolio
-      title="Property Overview"
-      description="Review your current opportunities and keep tabs on potential acquisitions."
-      properties={$propertyCards}
-      on:manage={handleManageEvent}
-      on:purchase={handlePurchaseEvent}
-    />
-  </div>
-  <div class="row g-4 mt-1">
-    <RentalStatus items={$rentalItems} on:manage={handleManageEvent} />
   </div>
 {:else if activeTab === 'market'}
   <div class="row g-4">
@@ -264,8 +251,17 @@
       on:purchase={handlePurchaseEvent}
     />
   </div>
+  <div class="row g-4 mt-1">
+    <RentalStatus items={$rentalItems} on:manage={handleManageEvent} />
+  </div>
 {:else}
   <div class="row g-4">
+    <GameSettings
+      speed={$speedLabel}
+      speedOptions={speedOptions}
+      on:speedchange={handleSpeedChange}
+      on:reset={handleReset}
+    />
     <ActivityHistory entries={$historyEntries} />
   </div>
 {/if}


### PR DESCRIPTION
## Summary
- simplify the dashboard to a single informational game snapshot card
- introduce a simulation settings card with speed and reset controls inside the settings tab
- expand portfolio, rental, and history cards to use the full tab width for improved spacing
- render the monthly cash flow label as HTML so markup no longer appears in the dashboard footer

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e51b2a4fcc832b92a2166d40352702