### PR TITLE
Restore legacy rent strategy ranges and tenant probabilities

### DIFF
--- a/src/lib/components/ManagementModal.svelte
+++ b/src/lib/components/ManagementModal.svelte
@@ -135,6 +135,12 @@
   const rentSliderMax = $derived.by(() =>
     Math.max(leasingControls.rentPremiumOptions.length - 1, 0)
   );
+  const hasLeaseOptions = $derived.by(
+    () => leasingControls.leaseMonthsOptions.length > 0
+  );
+  const hasRentPremiumOptions = $derived.by(
+    () => leasingControls.rentPremiumOptions.length > 0
+  );
   const leaseIndex = $derived.by(() => {
     const idx = leasingControls.leaseMonthsOptions.findIndex(
       (value) => value === leasingControls.selectedLeaseMonths
@@ -207,7 +213,7 @@
   }
 
   function handleLeaseSliderChange(event: Event) {
-    if (!propertyId || leaseSliderMax <= 0) {
+    if (!propertyId || leasingControls.leaseMonthsOptions.length === 0) {
       return;
     }
     const input = event.target as HTMLInputElement | null;
@@ -226,7 +232,7 @@
   }
 
   function handleRentSliderChange(event: Event) {
-    if (!propertyId || rentSliderMax <= 0) {
+    if (!propertyId || leasingControls.rentPremiumOptions.length === 0) {
       return;
     }
     const input = event.target as HTMLInputElement | null;
@@ -386,7 +392,7 @@
                 {@html leasingHtml}
                 {#if isOwned}
                   <div class="leasing-controls mt-3 d-flex flex-column gap-3">
-                    {#if leaseSliderMax > 0}
+                    {#if hasLeaseOptions}
                       <div>
                         <label for="leaseLengthRange" class="form-label fw-semibold">Lease length</label>
                         <input
@@ -410,7 +416,7 @@
                         {/if}
                       </div>
                     {/if}
-                    {#if rentSliderMax > 0}
+                    {#if hasRentPremiumOptions}
                       <div>
                         <label for="rentPremiumRange" class="form-label fw-semibold">Rent premium</label>
                         <input

--- a/src/lib/stores/game.test.ts
+++ b/src/lib/stores/game.test.ts
@@ -2,7 +2,43 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 
 import { MARKET_CONFIG } from '$lib/config';
-import { gameState, initialiseGame, tickDay } from './game';
+import { gameState, getRentStrategies, initialiseGame, tickDay } from './game';
+
+type TestProperty = Parameters<typeof getRentStrategies>[0];
+
+function createProperty(overrides: Partial<TestProperty> = {}): TestProperty {
+  const base = {
+    id: 'test-property',
+    name: 'Test Property',
+    description: 'A property used for rent strategy tests.',
+    propertyType: 'apartment',
+    bedrooms: 2,
+    bathrooms: 1,
+    features: [],
+    locationDescriptor: 'Central location',
+    demandScore: 8,
+    location: {
+      proximity: 0.5,
+      schoolRating: 6,
+      crimeScore: 4
+    },
+    baseValue: 320_000,
+    cost: 300_000,
+    maintenancePercent: 70,
+    monthlyRentEstimate: 1_800,
+    rentPlanId: '',
+    tenant: null,
+    mortgage: null,
+    autoRelist: true,
+    rentalMarketingPausedForMaintenance: false,
+    maintenanceWork: null,
+    marketAge: 0,
+    introducedOnDay: 1,
+    vacancyMonths: 0
+  } as TestProperty;
+
+  return { ...base, ...overrides };
+}
 
 describe('market listing lifecycle', () => {
   beforeEach(() => {
@@ -52,5 +88,60 @@ describe('market listing lifecycle', () => {
 
     const updated = get(gameState);
     expect(updated.market).toHaveLength(0);
+  });
+});
+
+describe('getRentStrategies', () => {
+  it('returns expanded lease and premium combinations with rent derived from base rate', () => {
+    const property = createProperty();
+    const baseRate = 0.03;
+
+    const plans = getRentStrategies(property, baseRate);
+
+    expect(plans).toHaveLength(50);
+
+    const leaseMonths = Array.from(new Set(plans.map((plan) => plan.leaseMonths))).sort((a, b) => a - b);
+    expect(leaseMonths).toEqual([6, 12, 18, 24, 36]);
+
+    const premiums = Array.from(new Set(plans.map((plan) => plan.rateOffset))).sort((a, b) => a - b);
+    expect(premiums).toEqual([0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1]);
+
+    const shortPlan = plans.find(
+      (plan) => plan.leaseMonths === 6 && Math.abs(plan.rateOffset - 0.01) < 1e-6
+    );
+    expect(shortPlan?.monthlyRent).toBeCloseTo(1_000, 2);
+
+    const midPlan = plans.find(
+      (plan) => plan.leaseMonths === 12 && Math.abs(plan.rateOffset - 0.05) < 1e-6
+    );
+    expect(midPlan?.monthlyRent).toBeCloseTo(2_000, 2);
+
+    const longPlan = plans.find(
+      (plan) => plan.leaseMonths === 36 && Math.abs(plan.rateOffset - 0.1) < 1e-6
+    );
+    expect(longPlan?.monthlyRent).toBeCloseTo(3_250, 2);
+  });
+
+  it('reacts to lease length and premium when calculating tenant probability', () => {
+    const property = createProperty({ demandScore: 8 });
+    const baseRate = 0.03;
+
+    const plans = getRentStrategies(property, baseRate);
+
+    const shortLowPremium = plans.find(
+      (plan) => plan.leaseMonths === 6 && Math.abs(plan.rateOffset - 0.01) < 1e-6
+    );
+    const balancedPlan = plans.find(
+      (plan) => plan.leaseMonths === 24 && Math.abs(plan.rateOffset - 0.05) < 1e-6
+    );
+    const longHighPremium = plans.find(
+      (plan) => plan.leaseMonths === 36 && Math.abs(plan.rateOffset - 0.1) < 1e-6
+    );
+
+    expect(shortLowPremium?.probability).toBeCloseTo(0.544, 3);
+    expect(balancedPlan?.probability).toBeCloseTo(0.529, 3);
+    expect(longHighPremium?.probability).toBeCloseTo(0.272, 3);
+
+    expect(shortLowPremium!.probability).toBeGreaterThan(longHighPremium!.probability);
   });
 });


### PR DESCRIPTION
## Summary
- reintroduce the legacy lease length and premium offset sets and compute rent from the base rate plus offset
- restore tenant placement probability logic and ensure leasing controls reflect the expanded option set
- add targeted store tests that validate rent strategy combinations and probability behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e53364512c832ba8289f8ce584ed17