### PR TITLE
Add property sale workflow and tests

### DIFF
--- a/src/lib/components/ManagementModal.svelte
+++ b/src/lib/components/ManagementModal.svelte
@@ -4,7 +4,8 @@
   import {
     createEmptyMaintenanceState,
     type ManagementLeasingControls,
-    type ManagementMaintenanceState
+    type ManagementMaintenanceState,
+    type ManagementSaleState
   } from '$lib/stores/game';
   import { formatCurrency, formatLeaseCountdown, formatPercentage } from '$lib/utils';
 
@@ -23,6 +24,7 @@
     autorelisttoggle: { propertyId: string; enabled: boolean };
     marketingtoggle: { propertyId: string; paused: boolean };
     maintenanceschedule: { propertyId: string };
+    sell: { propertyId: string };
   }>();
 
   const emptyLeasingControls: ManagementLeasingControls = {
@@ -51,7 +53,8 @@
     propertyId = '',
     isOwned = false,
     leasingControls = emptyLeasingControls,
-    maintenanceState = emptyMaintenanceState
+    maintenanceState = emptyMaintenanceState,
+    saleState = null as ManagementSaleState | null
   } = $props();
 
   let modalElement: HTMLDivElement | null = null;
@@ -277,6 +280,13 @@
       return;
     }
     dispatch('maintenanceschedule', { propertyId });
+  }
+
+  function handleSaleClick() {
+    if (!propertyId || !saleState) {
+      return;
+    }
+    dispatch('sell', { propertyId });
   }
 </script>
 
@@ -507,6 +517,36 @@
             >
               <div id="managementTransactions">
                 {@html transactionsHtml}
+                {#if saleState}
+                  <div class="section-card mt-3">
+                    <h6>Ownership actions</h6>
+                    <p class="mb-1">
+                      <strong>Projected sale:</strong> {formatCurrency(saleState.salePrice)}
+                      {#if saleState.outstandingBalance > 0}
+                        (net {formatCurrency(saleState.netProceeds)} after repaying
+                        {formatCurrency(saleState.outstandingBalance)})
+                      {:else}
+                        (net {formatCurrency(saleState.netProceeds)})
+                      {/if}
+                    </p>
+                    {#if saleState.restrictions.length > 0}
+                      <ul class="small text-muted mb-2">
+                        {#each saleState.restrictions as restriction}
+                          <li>{restriction}</li>
+                        {/each}
+                      </ul>
+                    {/if}
+                    <button
+                      type="button"
+                      class="btn btn-outline-danger"
+                      onclick={handleSaleClick}
+                      disabled={!saleState.canSell}
+                      title={!saleState.canSell ? saleState.restrictions.join(' ') : undefined}
+                    >
+                      Sell property
+                    </button>
+                  </div>
+                {/if}
               </div>
             </div>
             <div

--- a/src/lib/components/PropertyPortfolio.svelte
+++ b/src/lib/components/PropertyPortfolio.svelte
@@ -5,6 +5,7 @@
   const dispatch = createEventDispatcher<{
     manage: string;
     purchase: string;
+    sell: string;
   }>();
 
   let {
@@ -21,6 +22,10 @@
 
   function handlePurchase(propertyId: string) {
     dispatch('purchase', propertyId);
+  }
+
+  function handleSell(propertyId: string) {
+    dispatch('sell', propertyId);
   }
 </script>
 
@@ -120,6 +125,18 @@
                     >
                       Purchase
                     </button>
+                    {#if property.showSell}
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger"
+                        onclick={() => handleSell(property.id)}
+                        disabled={property.sellDisabled}
+                        title={property.sellDisabled ? property.sellDisabledReason : undefined}
+                        aria-label={`Sell ${property.name}`}
+                      >
+                        {property.sellLabel ?? 'Sell'}
+                      </button>
+                    {/if}
                   </div>
                 </div>
               </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,10 @@ export type PropertyCard = {
   owned?: boolean;
   disablePurchase?: boolean;
   manageLabel?: string;
+  showSell?: boolean;
+  sellLabel?: string;
+  sellDisabled?: boolean;
+  sellDisabledReason?: string;
 };
 
 export type RentalItemAction = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     setPropertyAutoRelist,
     setPropertyMarketingPaused,
     schedulePropertyMaintenance,
+    sellProperty,
     selectFinanceDeposit,
     selectFinanceTerm,
     selectFinanceFixedPeriod,
@@ -104,6 +105,10 @@
     purchaseProperty(event.detail);
   }
 
+  function handleSellEvent(event: CustomEvent<string>) {
+    sellProperty(event.detail);
+  }
+
   function handleManagementSectionChange(event: CustomEvent<string>) {
     setManagementSection(event.detail as 'overview' | 'leasing' | 'financing' | 'transactions' | 'maintenance');
   }
@@ -164,6 +169,13 @@
     const { propertyId } = event.detail ?? {};
     if (propertyId) {
       schedulePropertyMaintenance(propertyId);
+    }
+  }
+
+  function handleManagementSellEvent(event: CustomEvent<{ propertyId: string }>) {
+    const { propertyId } = event.detail ?? {};
+    if (propertyId) {
+      sellProperty(propertyId);
     }
   }
 
@@ -238,6 +250,7 @@
       showEmptyStateMessage={marketProperties.length === 0}
       on:manage={handleManageEvent}
       on:purchase={handlePurchaseEvent}
+      on:sell={handleSellEvent}
     />
   </div>
 {:else if activeTab === 'portfolio'}
@@ -249,6 +262,7 @@
       showEmptyStateMessage={ownedProperties.length === 0}
       on:manage={handleManageEvent}
       on:purchase={handlePurchaseEvent}
+      on:sell={handleSellEvent}
     />
   </div>
   <div class="row g-4 mt-1">
@@ -278,6 +292,7 @@
   maintenanceHtml={$managementView.maintenanceHtml}
   propertyId={$managementView.propertyId}
   isOwned={$managementView.isOwned}
+  saleState={$managementView.saleState}
   leasingControls={$managementView.leasingControls}
   maintenanceState={$managementView.maintenanceState}
   on:sectionchange={handleManagementSectionChange}
@@ -286,6 +301,7 @@
   on:autorelisttoggle={handleAutoRelistToggleEvent}
   on:marketingtoggle={handleMarketingToggleEvent}
   on:maintenanceschedule={handleMaintenanceScheduleEvent}
+  on:sell={handleManagementSellEvent}
   on:hide={closeManagement}
 />
 


### PR DESCRIPTION
## Summary
- surface sale eligibility messaging and a sell CTA in the portfolio cards and management modal
- implement a sellProperty store action that enforces maintenance requirements, repays mortgages, and logs history
- add unit tests covering failed sale attempts, successful proceeds, and mortgage clearance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e542b6dc94832bb49ee53dbcdb9d6f