### PR TITLE
Pause game while management and finance modals are open

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,8 @@
     purchaseProperty,
     setManagementSection,
     closeManagement,
+    pauseGame,
+    resumeGame,
     setPropertyLeaseMonths,
     setPropertyRentPremium,
     setPropertyAutoRelist,
@@ -187,6 +189,20 @@
     cancelFinance();
   }
 
+  function handleModalShow() {
+    pauseGame();
+  }
+
+  function handleManagementHide() {
+    closeManagement();
+    resumeGame();
+  }
+
+  function handleFinanceHide() {
+    closeFinance();
+    resumeGame();
+  }
+
   onMount(() => {
     initialiseGame();
 
@@ -302,7 +318,8 @@
   on:marketingtoggle={handleMarketingToggleEvent}
   on:maintenanceschedule={handleMaintenanceScheduleEvent}
   on:sell={handleManagementSellEvent}
-  on:hide={closeManagement}
+  on:show={handleModalShow}
+  on:hide={handleManagementHide}
 />
 
 <FinanceModal
@@ -321,5 +338,6 @@
   on:paymenttypechange={handlePaymentTypeChangeEvent}
   on:confirm={handleFinanceConfirm}
   on:cancel={handleFinanceCancel}
-  on:hide={closeFinance}
+  on:show={handleModalShow}
+  on:hide={handleFinanceHide}
 />


### PR DESCRIPTION
## Summary
- track modal-driven pause depth in the game store so overlapping modals keep the game paused and resume to the prior state
- pause and resume the game when the management and finance modals emit show/hide events
- add regression tests covering modal pause depth and restoration of the previous pause state

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e56c883090832bb2798b3ef70fcc44