### PR TITLE
Add rental marketing controls for vacant properties

### DIFF
--- a/src/lib/components/ManagementModal.test.ts
+++ b/src/lib/components/ManagementModal.test.ts
@@ -35,6 +35,7 @@ const defaultProps = {
     selectedLeaseMonths: 12,
     selectedRateOffset: 0.05,
     autoRelist: false,
+    marketingActive: false,
     marketingPaused: false,
     hasTenant: false
   },
@@ -102,6 +103,7 @@ describe('ManagementModal', () => {
     const leaseChanges: Array<{ propertyId: string; leaseMonths: number }> = [];
     const rentChanges: Array<{ propertyId: string; rateOffset: number }> = [];
     const autoRelistChanges: Array<{ propertyId: string; enabled: boolean }> = [];
+    const marketingActions: Array<{ propertyId: string; active: boolean }> = [];
     const marketingChanges: Array<{ propertyId: string; paused: boolean }> = [];
 
     render(ManagementModal, {
@@ -110,6 +112,7 @@ describe('ManagementModal', () => {
         leasechange: (event) => leaseChanges.push(event.detail),
         rentchange: (event) => rentChanges.push(event.detail),
         autorelisttoggle: (event) => autoRelistChanges.push(event.detail),
+        marketingaction: (event) => marketingActions.push(event.detail),
         marketingtoggle: (event) => marketingChanges.push(event.detail)
       }
     });
@@ -117,16 +120,19 @@ describe('ManagementModal', () => {
     const leaseSlider = screen.getByLabelText('Lease length') as HTMLInputElement;
     const rentSlider = screen.getByLabelText('Rent premium') as HTMLInputElement;
     const autoRelistToggle = screen.getByLabelText('Auto-relist vacant property') as HTMLInputElement;
+    const marketingActionButton = screen.getByRole('button', { name: 'List for rent' });
     const marketingToggle = screen.getByLabelText('Pause marketing for maintenance') as HTMLInputElement;
 
     await fireEvent.change(leaseSlider, { target: { value: '1' } });
     await fireEvent.change(rentSlider, { target: { value: '0' } });
     await fireEvent.click(autoRelistToggle);
+    await fireEvent.click(marketingActionButton);
     await fireEvent.click(marketingToggle);
 
     expect(leaseChanges.at(-1)).toEqual({ propertyId: 'prop-1', leaseMonths: 12 });
     expect(rentChanges.at(-1)).toEqual({ propertyId: 'prop-1', rateOffset: 0.03 });
     expect(autoRelistChanges.at(-1)).toEqual({ propertyId: 'prop-1', enabled: true });
+    expect(marketingActions.at(-1)).toEqual({ propertyId: 'prop-1', active: true });
     expect(marketingChanges.at(-1)).toEqual({ propertyId: 'prop-1', paused: true });
   });
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     setPropertyLeaseMonths,
     setPropertyRentPremium,
     setPropertyAutoRelist,
+    setPropertyRentalMarketingActive,
     setPropertyMarketingPaused,
     schedulePropertyMaintenance,
     sellProperty,
@@ -155,6 +156,15 @@
     const { propertyId, enabled } = event.detail;
     if (propertyId) {
       setPropertyAutoRelist(propertyId, enabled);
+    }
+  }
+
+  function handleMarketingActionEvent(
+    event: CustomEvent<{ propertyId: string; active: boolean }>
+  ) {
+    const { propertyId, active } = event.detail;
+    if (propertyId) {
+      setPropertyRentalMarketingActive(propertyId, active);
     }
   }
 
@@ -315,6 +325,7 @@
   on:leasechange={handleLeaseChangeEvent}
   on:rentchange={handleRentChangeEvent}
   on:autorelisttoggle={handleAutoRelistToggleEvent}
+  on:marketingaction={handleMarketingActionEvent}
   on:marketingtoggle={handleMarketingToggleEvent}
   on:maintenanceschedule={handleMaintenanceScheduleEvent}
   on:sell={handleManagementSellEvent}


### PR DESCRIPTION
## Summary
- reintroduce a rentalMarketingActive flag on owned properties and update monthly processing to respect marketing state and auto-relisting
- add management UI controls to list or pause marketing and wire them to a new store action
- extend unit coverage for marketing toggles and tenant placement behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5752c9a80832bab69c011aaffd9be