### PR TITLE
Add management refinance workflow

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -41,6 +41,8 @@
     setPropertyMarketingPaused,
     schedulePropertyMaintenance,
     sellProperty,
+    setManagementRefinanceFixedPeriod,
+    confirmManagementRefinance,
     selectFinanceDeposit,
     selectFinanceTerm,
     selectFinanceFixedPeriod,
@@ -191,6 +193,22 @@
     }
   }
 
+  function handleRefinancePeriodChangeEvent(
+    event: CustomEvent<{ propertyId: string; years: number }>
+  ) {
+    const { propertyId, years } = event.detail ?? {};
+    if (propertyId && Number.isFinite(years)) {
+      setManagementRefinanceFixedPeriod(years);
+    }
+  }
+
+  function handleRefinanceConfirmEvent(event: CustomEvent<{ propertyId: string }>) {
+    const { propertyId } = event.detail ?? {};
+    if (propertyId) {
+      confirmManagementRefinance(propertyId);
+    }
+  }
+
   function handleFinanceConfirm() {
     confirmFinance();
   }
@@ -329,6 +347,8 @@
   on:marketingtoggle={handleMarketingToggleEvent}
   on:maintenanceschedule={handleMaintenanceScheduleEvent}
   on:sell={handleManagementSellEvent}
+  on:refinanceperiodchange={handleRefinancePeriodChangeEvent}
+  on:refinanceconfirm={handleRefinanceConfirmEvent}
   on:show={handleModalShow}
   on:hide={handleManagementHide}
 />


### PR DESCRIPTION
## Summary
- add refinance state, view derivation, and confirmation logic in the game store to support variable-rate mortgages
- render refinance controls in the management modal with selectable fixed terms and payment change preview
- connect refinance events in the main page and extend modal and store tests for the new workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6064f9b68832b84aaaa1ab3e75120