### PR TITLE
Adjust tenant placement probability with vacancy streaks

### DIFF
--- a/src/lib/stores/game.ts
+++ b/src/lib/stores/game.ts
@@ -1269,8 +1269,17 @@ function processMonthlyTick(state: GameState): GameState {
         if (updated.rentalMarketingActive) {
           const plans = getRentStrategies(updated, state.centralBankRate);
           const selectedPlan = plans.find((plan) => plan.id === updated.rentPlanId) ?? plans[0];
-          const successChance = selectedPlan?.probability ?? 0.2;
-          const vacancyMonths = (updated.vacancyMonths ?? 0) + 1;
+          const vacancyMonths = Math.max((updated.vacancyMonths ?? 0) + 1, 1);
+          const baseChance = selectedPlan?.probability ?? 0.2;
+          const vacancyBoost = Math.min(Math.max((vacancyMonths - 1) * 0.08, 0), 0.3);
+          const demandAdjustment = Math.min(
+            (clampDemandScore(updated.demandScore) - 5) * 0.02,
+            0.2
+          );
+          const successChance = Math.min(
+            Math.max(baseChance + vacancyBoost + demandAdjustment, 0.01),
+            0.98
+          );
           if (Math.random() < successChance) {
             updated = {
               ...updated,


### PR DESCRIPTION
## Summary
- track vacancy streaks while marketing and apply vacancy/demand boosts when placing tenants
- ensure vacancy counters reset on success and expand tests to cover higher placement odds after prolonged vacancy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e60b098bcc832bb8504fbccec531e0